### PR TITLE
Version control for main.js and main.css with last commit hash 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,16 @@
-# Python
-__pycache__
-*.pyc 
+# Editor
+.vscode
+
+# Environment
+.env
 
 # Pelican
 ## Build Folder
 output
 
-# Editor
-.vscode
+# Python
+__pycache__
+*.pyc 
 
 # Webpack
 node_modules

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Please make sure to read the [Contributing Guide](./CONTRIBUTING.md) before maki
 
 ## Changelog
 
+- 2020-09-20 The last commit hash is used as version number for main.js and main.css.
 - 2020-09-20 Bundle css and js for production with webpack
 - 2020-09-19 Add tailwindcss and webpack
 - 2020-09-18 Improve Pelican Settings

--- a/README.md
+++ b/README.md
@@ -8,19 +8,10 @@ A simple blog, created with the Static Site Generator [Pelican](https://getpelic
 
 To run the project locally, python version 3.6+ and node version v12.18.3 are required. Use the following commands and you are ready to go.
 
-### Python Dependencies
 ```
-pip install pelican
-pip install markdown
-pip install invoke
-pip install livereload
-```
-
-### Node Dependencies
-```
+pip install -r requirements.txt
 npm install
 ```
-
 
 ### Compiles and hot-reloads for development
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*- #
 
+import os
+import sys
+from dotenv import load_dotenv
+load_dotenv()
+
+
 AUTHOR = 'Daniel Naschberger'
 SITENAME = 'milena-and-her-dog.com'
 SITEURL = ''
@@ -11,6 +17,13 @@ DEFAULT_LANG = 'de'
 
 GITHUB_URL = 'https://github.com/naschidaniel/milena-and-her-dog'
 
+
+# Read Environment Variables
+try:
+    LASTCOMMIT = os.getenv("LASTCOMMIT")
+except:
+    print("Can not read .env file")
+    sys.exit(1)
 
 # Template
 THEME = 'themes/milena'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pelican
+markdown
+invoke
+livereload
+python-dotenv

--- a/tasks.py
+++ b/tasks.py
@@ -39,6 +39,7 @@ def clean(c):
 @task
 def build(c):
     """Build local version of site"""
+    set_environment_variables(c)
     pelican_run('-s {settings_base}'.format(**CONFIG))
 
 @task
@@ -146,6 +147,24 @@ def production(c):
     clean(c)
     npm_build(c)
     build(c)
+
+@task
+def set_environment_variables(c):
+    """A function to write local environment variables"""
+    lastcommit = c.run("git rev-parse --short HEAD")
+    lastcommit = lastcommit.stdout.strip()
+    print(f"The last commit number is {lastcommit}.")
+
+    env_variables = {"LASTCOMMIT": lastcommit}
+    try:
+        with open(".env", "w") as f:
+            for key, value in env_variables.items():
+                f.write(f"{key}={value}\n")
+            f.close()
+        print("The environment file was written.")
+
+    except:
+        print("The environment variable cannot be written.")
 
 
 def pelican_run(cmd):

--- a/themes/milena/templates/base.html
+++ b/themes/milena/templates/base.html
@@ -15,7 +15,7 @@
   <link href="{{ SITEURL }}" rel="canonical" />
 
   <!-- Styling -->
-  <link href="/theme/css/main.css" type="text/css" rel="stylesheet" />
+  <link href="/theme/css/main.css?v={{ LASTCOMMIT }}" type="text/css" rel="stylesheet" />
   {% endblock head %}
 
 </head>
@@ -29,7 +29,7 @@
 
   {% include './footer.html' %}
   
-  <script src="/theme/js/main.js"></script>
+  <script src="/theme/js/main.js?v={{ LASTCOMMIT }}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
It is always useful if the browser knows if the Javascript and CSS files need to be reloaded. As version number the last commit is used.